### PR TITLE
Add link integrity retrievers for Volto blocks

### DIFF
--- a/artifacts/link-integrity-retrievers.md
+++ b/artifacts/link-integrity-retrievers.md
@@ -1,0 +1,56 @@
+# Specification: Volto Block Link Integrity Retrievers for Climate-ADAPT
+
+## Overview
+This specification describes the implementation of custom link integrity discovery for Volto blocks within the `eea.climateadapt` ecosystem. Its primary goal is to ensure that internal links stored in custom Volto block structures (specifically `object_list` fields) are correctly tracked by Plone's `zc.relation` catalog.
+
+## The Problem
+Plone's default block link integrity discovery (`plone.restapi.blocks_linkintegrity.GenericBlockLinksRetriever`) only automatically extracts links from three top-level fields:
+1. `url`
+2. `href`
+3. `preview_image`
+
+However, many custom Climate-ADAPT blocks store links in more complex or differently-named structures:
+*   **Nested Lists**: `ContentLinks`, `RelevantAceContent`, and `ASTNavigation` use an `object_list` (usually named `items`) where each entry contains a link field named `source` or `href`.
+*   **Custom Top-level Fields**: Some variations or shadowed blocks might use `linkTo` (standard Volto listing) or `image`.
+
+Without custom retrievers, these links are invisible to Plone's link integrity system, leading to broken links when the target content is moved or deleted without warning.
+
+## Implementation Detail
+
+### 1. New Link Retriever Adapter
+A new subscriber adapter `CCAObjectListLinksRetriever` has been implemented in:
+`eea/climateadapt/restapi/blocks_linkintegrity.py`
+
+#### Extraction Logic:
+*   **Nested Items**: It iterates through the `items` list if present. For each dictionary item, it extracts internal links from `source`, `href`, and `url` fields.
+*   **Additional Fields**: It also checks for top-level `linkTo` and `image` fields.
+*   **Discovery**: It uses `plone.restapi.blocks_linkintegrity.get_urls_from_value` to correctly handle `resolveuid/` patterns within strings, dictionaries, or lists.
+
+### 2. Registration
+The retriever is registered as a subscriber to the `IBlockFieldLinkIntegrityRetriever` interface in:
+`eea/climateadapt/restapi/configure.zcml`
+
+```xml
+  <subscriber
+    factory=".blocks_linkintegrity.CCAObjectListLinksRetriever"
+    provides="plone.restapi.interfaces.IBlockFieldLinkIntegrityRetriever"
+  />
+```
+
+## Affected Blocks and Fields
+
+| Block (@type) | Field Location | Covered by Default? | Covered by New Retriever? |
+| :--- | :--- | :--- | :--- |
+| `ContentLinks` | `items[*].source` | No | **Yes** |
+| `RelevantAceContent` | `items[*].source` | No | **Yes** |
+| `ASTNavigation` | `items[*].href` | No | **Yes** |
+| `Listing` (Shadowed) | `linkTo` | No | **Yes** |
+| `RedirectBlock` | `href` | Yes | Yes |
+| `CountryMapObservatory`| `href` | Yes | Yes |
+| `CollectionStatistics` | `href` | Yes | Yes |
+
+## Recommendations for Future Blocks
+When developing new Volto blocks for Climate-ADAPT:
+1.  **Naming**: Prefer standard field names (`url`, `href`, `preview_image`) at the top level when possible.
+2.  **Nesting**: If links must be nested in a list, ensure they are inside an `items` list and use `source`, `href`, or `url` as the property name to benefit from this retriever.
+3.  **UIDs**: Always store internal links in the `resolveuid/<UID>` format.

--- a/eea/climateadapt/restapi/blocks_linkintegrity.py
+++ b/eea/climateadapt/restapi/blocks_linkintegrity.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+from plone.restapi.behaviors import IBlocks
+from plone.restapi.interfaces import IBlockFieldLinkIntegrityRetriever
+from zope.component import adapter
+from zope.interface import implementer
+from zope.publisher.interfaces.browser import IBrowserRequest
+from plone.restapi.blocks_linkintegrity import get_urls_from_value
+
+
+@adapter(IBlocks, IBrowserRequest)
+@implementer(IBlockFieldLinkIntegrityRetriever)
+class CCAObjectListLinksRetriever(object):
+    """Retrieves links from object_list fields (items) used in CCA blocks.
+
+    This covers blocks like ContentLinks, RelevantAceContent, and ASTNavigation
+    where links are nested within an 'items' list.
+    """
+
+    order = 10
+    block_type = None
+
+    def __init__(self, context, request):
+        self.context = context
+        self.request = request
+
+    def __call__(self, block):
+        links = []
+        # Typical CCA blocks store nested links in 'items'
+        items = block.get("items", [])
+        if not isinstance(items, list):
+            items = []
+
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+
+            # We check fields that are known to contain links in CCA object_lists
+            for field in ["source", "href", "url"]:
+                value = item.get(field)
+                if not value:
+                    continue
+
+                for url in get_urls_from_value(value):
+                    if url not in links:
+                        links.append(url)
+
+        # Also check some top-level fields that might be missing from
+        # GenericBlockLinksRetriever (which covers url, href, preview_image)
+        for field in ["linkTo", "image"]:
+            value = block.get(field)
+            if not value:
+                continue
+            for url in get_urls_from_value(value):
+                if url not in links:
+                    links.append(url)
+
+        return links

--- a/eea/climateadapt/restapi/configure.zcml
+++ b/eea/climateadapt/restapi/configure.zcml
@@ -144,6 +144,11 @@
   />
 
   <subscriber
+    factory=".blocks_linkintegrity.CCAObjectListLinksRetriever"
+    provides="plone.restapi.interfaces.IBlockFieldLinkIntegrityRetriever"
+  />
+
+  <subscriber
     factory=".blocks.SearchAceContentBlockSerializer"
     provides="plone.restapi.interfaces.IBlockFieldSerializationTransformer"
   />


### PR DESCRIPTION
This PR adds a custom IBlockFieldLinkIntegrityRetriever adapter to extract internal links from nested object_list fields (like ContentLinks, RelevantAceContent, and ASTNavigation) and other block fields (linkTo, image) in Climate-ADAPT.