### PR TITLE
fix: handle broken order keys in migrate_eionet_groups script

### DIFF
--- a/eea/climateadapt/scripts/MIGRATE_EIONET_GROUPS.md
+++ b/eea/climateadapt/scripts/MIGRATE_EIONET_GROUPS.md
@@ -13,6 +13,7 @@ Climate-ADAPT is moving away from direct LDAP group mapping for local roles in f
 - **Idempotency**: The script can be run multiple times. If a `local-*` group already has the same roles as the `extranet-*` group on an object, it won't be duplicated.
 - **Dry-run Mode**: Enabled by default, allowing you to see what changes would be made without actually modifying the database.
 - **Iterative Traversal**: Uses a stack-based approach for robustness and to avoid recursion depth issues.
+- **Broken Order Key Resilience**: If a folder has a broken order key (an ID present in the folder ordering but missing from the BTree), the affected child is skipped with a logged error message and the traversal continues. If `objectIds()` itself fails for a folder, the entire folder is skipped with a logged error.
 
 ## How to Run
 
@@ -41,3 +42,4 @@ docker compose exec backend /app/docker-entrypoint.sh bin/migrate_eionet_groups 
 - **Group Prefix**: It looks for principals starting with `extranet-` and maps them to `local-`.
 - **Plone Groups**: It uses `portal_groups` to create the new groups if they don't exist.
 - **Transaction Management**: When running in non-dry-run mode, it commits the transaction at the end.
+- **Child Retrieval Strategy**: Uses `objectIds()` + `_getOb()` instead of `objectValues()` to avoid crashes from `Lazy` sequence iteration when broken order keys are encountered. This allows per-child error handling rather than failing the entire folder.

--- a/eea/climateadapt/scripts/migrate_eionet_groups.py
+++ b/eea/climateadapt/scripts/migrate_eionet_groups.py
@@ -123,19 +123,36 @@ def run(app):
         except Exception as e:
             logger.error(f"Error processing {path}: {e}")
 
-        # Recurse into children if it's folder-like
-        if hasattr(obj, "objectValues"):
+        # Recurse into children if it's folder-like. We use objectIds() + _getOb()
+        # instead of objectValues() because the latter returns a Lazy sequence
+        # that calls _getOb internally. If a folder has a broken order key
+        # (an ID present in the ordering but missing from the BTree), _getOb
+        # raises AttributeError mid-iteration, crashing the entire traversal.
+        # By retrieving each child individually we can skip just the broken
+        # child and continue processing the rest of the folder.
+        if hasattr(obj, "objectIds"):
             try:
-                children = obj.objectValues()
+                child_ids = obj.objectIds()
             except Exception as e:
-                logger.error(f"Error getting children for {path}: {e}")
+                logger.error(
+                    f"Error getting child IDs for {path}: {e}. Skipping folder."
+                )
                 continue
 
-            for child in children:
+            for child_id in child_ids:
                 try:
-                    child_id = child.getId()
+                    child = obj._getOb(child_id)
+                except (AttributeError, KeyError) as e:
+                    logger.error(
+                        f"Broken order key '{child_id}' in {path}: {e}. "
+                        f"Skipping this child."
+                    )
+                    continue
                 except Exception as e:
-                    logger.error(f"Error getting ID for child of {path}: {e}")
+                    logger.error(
+                        f"Error getting child '{child_id}' from {path}: {e}. "
+                        f"Skipping this child."
+                    )
                     continue
 
                 # Filter for content objects: must be Dexterity content or the portal root


### PR DESCRIPTION
The migrate_eionet_groups script crashed with AttributeError when traversing folders with broken order keys (an ID present in the folder ordering but missing from the BTree).

Root cause: obj.objectValues() returns a ZTUtils.Lazy sequence that calls _getOb() internally during iteration. When _getOb hits a broken order key, it raises AttributeError inside Lazy.__getitem__, which propagates out of the for loop before the per-child try/except can catch it.

Fix: Switched to objectIds() + _getOb() per child, with per-child error handling that logs and skips broken children while continuing to process the rest of the folder.